### PR TITLE
support node-red v1 async send api

### DIFF
--- a/diskio.js
+++ b/diskio.js
@@ -8,7 +8,8 @@ module.exports = function (RED) {
 
     const node = this
 
-    node.on('input', (msg) => {
+    node.on('input', (msg, send, done) => {
+      send = send || function() { node.send.apply(node,arguments) }
       si.disksIO()
         .then(data => {
           let payloadArr = []
@@ -20,10 +21,17 @@ module.exports = function (RED) {
             payload: data.wIO_sec,
             topic: 'diskio_write_sec'
           })
-          node.send([ payloadArr ])
+          send([ payloadArr ])
+          if (done) {
+            done()
+          }
         })
         .catch(err => {
-          node.error('SI diskdIO Error', err.message)
+          if (done) {
+            done(err)
+          } else {
+            node.error('SI diskdIO Error', err.message)
+          }
         })
     })
   }


### PR DESCRIPTION
The syntax for listening to an incoming message and sending a message is changing in Node-RED v1.
The post about this from the official Node-RED blog explains why it's changing, what's the new syntax, and how to maintain backward compatibility:
https://nodered.org/blog/2019/09/20/node-done

This PR changes the syntax based on the example from the blog post.

Thanks.